### PR TITLE
Use Access SQLAlchemy dialect pyodbc connection as a template for Dremio dialect for now

### DIFF
--- a/sqlalchemy_dremio/__init__.py
+++ b/sqlalchemy_dremio/__init__.py
@@ -17,5 +17,5 @@ __version__ = '0.1.0'
 
 from sqlalchemy.dialects import registry
 
-registry.register("access", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc")
-registry.register("access.pyodbc", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc")
+registry.register("dremio", "sqlalchemy_dremio.pyodbc", "DremioDialect_pyodbc")
+registry.register("dremio.pyodbc", "sqlalchemy_dremio.pyodbc", "DremioDialect_pyodbc")

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -1,0 +1,266 @@
+# sqlalchemy_dremio/base.py
+# Copyright (C) 2007-2012 the SQLAlchemy authors and contributors <see AUTHORS file>
+# Copyright (C) 2007 Paul Johnston, paj@pajhome.org.uk
+# Portions derived from jet2sql.py by Matt Keranen, mksql@yahoo.com
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+"""
+Support for the Dremio database.
+
+
+"""
+from sqlalchemy import sql, schema, types, exc, pool
+from sqlalchemy.sql import compiler, expression
+from sqlalchemy.engine import default, base, reflection
+from sqlalchemy import processors
+
+class AcNumeric(types.Numeric):
+    def get_col_spec(self):
+        return "NUMERIC"
+
+    def bind_processor(self, dialect):
+        return processors.to_str
+
+    def result_processor(self, dialect, coltype):
+        return None
+
+class AcFloat(types.Float):
+    def get_col_spec(self):
+        return "FLOAT"
+
+    def bind_processor(self, dialect):
+        """By converting to string, we can use Decimal types round-trip."""
+        return processors.to_str
+
+class AcInteger(types.Integer):
+    def get_col_spec(self):
+        return "INTEGER"
+
+class AcTinyInteger(types.Integer):
+    def get_col_spec(self):
+        return "TINYINT"
+
+class AcSmallInteger(types.SmallInteger):
+    def get_col_spec(self):
+        return "SMALLINT"
+
+class AcDateTime(types.DateTime):
+    def get_col_spec(self):
+        return "DATETIME"
+
+class AcDate(types.Date):
+
+    def get_col_spec(self):
+        return "DATETIME"
+
+class AcText(types.Text):
+    def get_col_spec(self):
+        return "MEMO"
+
+class AcString(types.String):
+    def get_col_spec(self):
+        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
+
+class AcUnicode(types.Unicode):
+    def get_col_spec(self):
+        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
+
+    def bind_processor(self, dialect):
+        return None
+
+    def result_processor(self, dialect, coltype):
+        return None
+
+class AcChar(types.CHAR):
+    def get_col_spec(self):
+        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
+
+class AcBinary(types.LargeBinary):
+    def get_col_spec(self):
+        return "BINARY"
+
+class AcBoolean(types.Boolean):
+    def get_col_spec(self):
+        return "YESNO"
+
+class AcTimeStamp(types.TIMESTAMP):
+    def get_col_spec(self):
+        return "TIMESTAMP"
+
+class DremioExecutionContext(default.DefaultExecutionContext):
+
+    def get_lastrowid(self):
+        self.cursor.execute("SELECT @@identity AS lastrowid")
+        return self.cursor.fetchone()[0]
+
+
+class DremioCompiler(compiler.SQLCompiler):
+    extract_map = compiler.SQLCompiler.extract_map.copy()
+    extract_map.update({
+            'month': 'm',
+            'day': 'd',
+            'year': 'yyyy',
+            'second': 's',
+            'hour': 'h',
+            'doy': 'y',
+            'minute': 'n',
+            'quarter': 'q',
+            'dow': 'w',
+            'week': 'ww'
+    })
+
+    def visit_cast(self, cast, **kwargs):
+        return cast.clause._compiler_dispatch(self, **kwargs)
+
+    def visit_select_precolumns(self, select):
+        """Dremio puts TOP, it's version of LIMIT here """
+        s = select.distinct and "DISTINCT " or ""
+        if select.limit:
+            s += "TOP %s " % (select.limit)
+        if select.offset:
+            raise exc.InvalidRequestError(
+                    'Dremio does not support LIMIT with an offset')
+        return s
+
+    def limit_clause(self, select):
+        """Limit in dremio is after the select keyword"""
+        return ""
+
+    def binary_operator_string(self, binary):
+        """Dremio uses "mod" instead of "%" """
+        return binary.operator == '%' and 'mod' or binary.operator
+
+    function_rewrites = {'current_date': 'now',
+                          'current_timestamp': 'now',
+                          'length': 'len',
+                          }
+    def visit_function(self, func, **kwargs):
+        """Dremio function names differ from the ANSI SQL names;
+        rewrite common ones"""
+        func.name = self.function_rewrites.get(func.name, func.name)
+        return super(DremioCompiler, self).visit_function(func)
+
+    def for_update_clause(self, select):
+        """FOR UPDATE is not supported by Dremio; silently ignore"""
+        return ''
+
+    # Strip schema
+    def visit_table(self, table, asfrom=False, **kwargs):
+        if asfrom:
+            return self.preparer.quote(table.name, table.quote)
+        else:
+            return ""
+
+    def visit_join(self, join, asfrom=False, **kwargs):
+        return ('(' + self.process(join.left, asfrom=True) + \
+                (join.isouter and " LEFT OUTER JOIN " or " INNER JOIN ") + \
+                self.process(join.right, asfrom=True) + " ON " + \
+                self.process(join.onclause) + ')')
+
+    def visit_extract(self, extract, **kw):
+        field = self.extract_map.get(extract.field, extract.field)
+        return 'DATEPART("%s", %s)' % \
+                    (field, self.process(extract.expr, **kw))
+
+class DremioDDLCompiler(compiler.DDLCompiler):
+    def get_column_specification(self, column, **kwargs):
+        if column.table is None:
+            raise exc.CompileError(
+                            "dremio requires Table-bound columns "
+                            "in order to generate DDL")
+
+        colspec = self.preparer.format_column(column)
+        seq_col = column.table._autoincrement_column
+        if seq_col is column:
+            colspec += " AUTOINCREMENT"
+        else:
+            colspec += " " + self.dialect.type_compiler.process(column.type)
+
+            if column.nullable is not None and not column.primary_key:
+                if not column.nullable or column.primary_key:
+                    colspec += " NOT NULL"
+                else:
+                    colspec += " NULL"
+
+            default = self.get_column_default_string(column)
+            if default is not None:
+                colspec += " DEFAULT " + default
+
+        return colspec
+
+    def visit_drop_index(self, drop):
+        index = drop.element
+        self.append("\nDROP INDEX [%s].[%s]" % \
+                        (index.table.name,
+                        self._index_identifier(index.name)))
+
+class DremioIdentifierPreparer(compiler.IdentifierPreparer):
+    reserved_words = compiler.RESERVED_WORDS.copy()
+    reserved_words.update(['value', 'text'])
+    def __init__(self, dialect):
+        super(DremioIdentifierPreparer, self).\
+                __init__(dialect, initial_quote='[', final_quote=']')
+
+
+
+class DremioDialect(default.DefaultDialect):
+    colspecs = {
+        types.Unicode: AcUnicode,
+        types.Integer: AcInteger,
+        types.SmallInteger: AcSmallInteger,
+        types.Numeric: AcNumeric,
+        types.Float: AcFloat,
+        types.DateTime: AcDateTime,
+        types.Date: AcDate,
+        types.String: AcString,
+        types.LargeBinary: AcBinary,
+        types.Boolean: AcBoolean,
+        types.Text: AcText,
+        types.CHAR: AcChar,
+        types.TIMESTAMP: AcTimeStamp,
+    }
+    name = 'dremio'
+    supports_sane_rowcount = False
+    supports_sane_multi_rowcount = False
+
+    poolclass = pool.SingletonThreadPool
+    statement_compiler = DremioCompiler
+    ddl_compiler = DremioDDLCompiler
+    preparer = DremioIdentifierPreparer
+    execution_ctx_cls = DremioExecutionContext
+
+    @classmethod
+    def dbapi(cls):
+        import pyodbc as module
+        return module
+
+    def create_connect_args(self, url):
+        opts = url.translate_connect_args()
+        connectors = ["Driver={Dremio Driver (*.mdb)}"]
+        connectors.append("Dbq=%s" % opts["database"])
+        user = opts.get("username", None)
+        if user:
+            connectors.append("UID=%s" % user)
+            connectors.append("PWD=%s" % opts.get("password", ""))
+        return [[";".join(connectors)], {}]
+
+    def last_inserted_ids(self):
+        return self.context.last_inserted_ids
+
+
+    def has_table(self, connection, tablename, schema=None):
+        result = connection.scalar(
+                        sql.text(
+                            "select count(*) from msysobjects where "
+                            "type=1 and name=:name"), name=tablename
+                        )
+        return bool(result)
+
+    @reflection.cache
+    def get_table_names(self, connection, schema=None, **kw):
+        result = connection.execute("select name from msysobjects where "
+                "type=1 and name not like 'MSys%'")
+        table_names = [r[0] for r in result]
+        return table_names

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -15,154 +15,65 @@ from sqlalchemy import sql, schema, types, exc, pool
 from sqlalchemy.sql import compiler, expression
 from sqlalchemy.engine import default, base, reflection
 from sqlalchemy import processors
+from sqlalchemy import VARCHAR, INTEGER, FLOAT, DATE, TIMESTAMP, TIME, Interval, DECIMAL, LargeBinary, BIGINT, SMALLINT
+import sqlalchemy
+import platform
 
-class AcNumeric(types.Numeric):
-    def get_col_spec(self):
-        return "NUMERIC"
-
-    def bind_processor(self, dialect):
-        return processors.to_str
-
-    def result_processor(self, dialect, coltype):
-        return None
-
-class AcFloat(types.Float):
-    def get_col_spec(self):
-        return "FLOAT"
-
-    def bind_processor(self, dialect):
-        """By converting to string, we can use Decimal types round-trip."""
-        return processors.to_str
-
-class AcInteger(types.Integer):
-    def get_col_spec(self):
-        return "INTEGER"
-
-class AcTinyInteger(types.Integer):
-    def get_col_spec(self):
-        return "TINYINT"
-
-class AcSmallInteger(types.SmallInteger):
-    def get_col_spec(self):
-        return "SMALLINT"
-
-class AcDateTime(types.DateTime):
-    def get_col_spec(self):
-        return "DATETIME"
-
-class AcDate(types.Date):
-
-    def get_col_spec(self):
-        return "DATETIME"
-
-class AcText(types.Text):
-    def get_col_spec(self):
-        return "MEMO"
-
-class AcString(types.String):
-    def get_col_spec(self):
-        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
-
-class AcUnicode(types.Unicode):
-    def get_col_spec(self):
-        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
-
-    def bind_processor(self, dialect):
-        return None
-
-    def result_processor(self, dialect, coltype):
-        return None
-
-class AcChar(types.CHAR):
-    def get_col_spec(self):
-        return "TEXT" + (self.length and ("(%d)" % self.length) or "")
-
-class AcBinary(types.LargeBinary):
-    def get_col_spec(self):
-        return "BINARY"
-
-class AcBoolean(types.Boolean):
-    def get_col_spec(self):
-        return "YESNO"
-
-class AcTimeStamp(types.TIMESTAMP):
-    def get_col_spec(self):
-        return "TIMESTAMP"
+_type_map = {
+    'boolean': types.BOOLEAN,
+    'BOOLEAN': types.BOOLEAN,
+    'varbinary': types.LargeBinary,
+    'VARBINARY': types.LargeBinary,
+    'date': types.DATE,
+    'DATE': types.DATE,
+    'float': types.FLOAT,
+    'FLOAT': types.FLOAT,    
+    'decimal': types.DECIMAL,
+    'DECIMAL': types.DECIMAL,
+    'double': types.FLOAT,
+    'DOUBLE': types.FLOAT,
+    'interval': types.Interval,
+    'INTERVAL': types.Interval,
+    'int': types.INTEGER,
+    'INT': types.INTEGER,
+    'integer': types.INTEGER,
+    'INTEGER': types.INTEGER,
+    'bigint': types.BIGINT,
+    'BIGINT': types.BIGINT,
+    'time': types.TIME,
+    'TIME': types.TIME,
+    'timestamp': types.TIMESTAMP,
+    'TIMESTAMP': types.TIMESTAMP,
+    'varchar': types.String,
+    'VARCHAR': types.String,
+    'smallint': types.SMALLINT,
+    'CHARACTER VARYING': types.String,
+    'ANY': types.String
+}
 
 class DremioExecutionContext(default.DefaultExecutionContext):
-
-    def get_lastrowid(self):
-        self.cursor.execute("SELECT @@identity AS lastrowid")
-        return self.cursor.fetchone()[0]
+    pass
 
 
-class DremioCompiler(compiler.SQLCompiler):
-    extract_map = compiler.SQLCompiler.extract_map.copy()
-    extract_map.update({
-            'month': 'm',
-            'day': 'd',
-            'year': 'yyyy',
-            'second': 's',
-            'hour': 'h',
-            'doy': 'y',
-            'minute': 'n',
-            'quarter': 'q',
-            'dow': 'w',
-            'week': 'ww'
-    })
+class DremioCompiler(compiler.SQLCompiler): 
+    def visit_char_length_func(self, fn, **kw):
+        return 'length{}'.format(self.function_argspec(fn, **kw))
 
-    def visit_cast(self, cast, **kwargs):
-        return cast.clause._compiler_dispatch(self, **kwargs)
-
-    def visit_select_precolumns(self, select):
-        """Dremio puts TOP, it's version of LIMIT here """
-        s = select.distinct and "DISTINCT " or ""
-        if select.limit:
-            s += "TOP %s " % (select.limit)
-        if select.offset:
-            raise exc.InvalidRequestError(
-                    'Dremio does not support LIMIT with an offset')
-        return s
-
-    def limit_clause(self, select):
-        """Limit in dremio is after the select keyword"""
-        return ""
-
-    def binary_operator_string(self, binary):
-        """Dremio uses "mod" instead of "%" """
-        return binary.operator == '%' and 'mod' or binary.operator
-
-    function_rewrites = {'current_date': 'now',
-                          'current_timestamp': 'now',
-                          'length': 'len',
-                          }
-    def visit_function(self, func, **kwargs):
-        """Dremio function names differ from the ANSI SQL names;
-        rewrite common ones"""
-        func.name = self.function_rewrites.get(func.name, func.name)
-        return super(DremioCompiler, self).visit_function(func)
-
-    def for_update_clause(self, select):
-        """FOR UPDATE is not supported by Dremio; silently ignore"""
-        return ''
-
-    # Strip schema
     def visit_table(self, table, asfrom=False, **kwargs):
+
         if asfrom:
-            return self.preparer.quote(table.name, table.quote)
+            if table.schema != "":
+                fixed_schema = ".".join(["`" + i.replace('`', '') + "`" for i in table.schema.split(".")])
+                fixed_table = fixed_schema + ".`" + table.name.replace("`", "") + "`"
+            else:
+                fixed_table = "`" + table.name.replace("`", "") + "`"
+            return fixed_table
         else:
             return ""
 
-    def visit_join(self, join, asfrom=False, **kwargs):
-        return ('(' + self.process(join.left, asfrom=True) + \
-                (join.isouter and " LEFT OUTER JOIN " or " INNER JOIN ") + \
-                self.process(join.right, asfrom=True) + " ON " + \
-                self.process(join.onclause) + ')')
 
-    def visit_extract(self, extract, **kw):
-        field = self.extract_map.get(extract.field, extract.field)
-        return 'DATEPART("%s", %s)' % \
-                    (field, self.process(extract.expr, **kw))
+    def visit_tablesample(self, tablesample, asfrom=False, **kw):
+        print( tablesample)
 
 class DremioDDLCompiler(compiler.DDLCompiler):
     def get_column_specification(self, column, **kwargs):
@@ -206,21 +117,6 @@ class DremioIdentifierPreparer(compiler.IdentifierPreparer):
 
 
 class DremioDialect(default.DefaultDialect):
-    colspecs = {
-        types.Unicode: AcUnicode,
-        types.Integer: AcInteger,
-        types.SmallInteger: AcSmallInteger,
-        types.Numeric: AcNumeric,
-        types.Float: AcFloat,
-        types.DateTime: AcDateTime,
-        types.Date: AcDate,
-        types.String: AcString,
-        types.LargeBinary: AcBinary,
-        types.Boolean: AcBoolean,
-        types.Text: AcText,
-        types.CHAR: AcChar,
-        types.TIMESTAMP: AcTimeStamp,
-    }
     name = 'dremio'
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
@@ -238,29 +134,36 @@ class DremioDialect(default.DefaultDialect):
 
     def create_connect_args(self, url):
         opts = url.translate_connect_args()
-        connectors = ["Driver={Dremio Driver (*.mdb)}"]
-        connectors.append("Dbq=%s" % opts["database"])
-        user = opts.get("username", None)
-        if user:
-            connectors.append("UID=%s" % user)
-            connectors.append("PWD=%s" % opts.get("password", ""))
-        return [[";".join(connectors)], {}]
+        driver_for_platf = {
+            'Linux 64bit': 'Dremio ODBC Driver 64-bit',
+            'Linux 32bit': 'Dremio ODBC Driver 32-bit',
+            'Windows' : 'Dremio Connector',
+            'Darwin': 'Dremio ODBC Driver'
+        }
+        platf = platform.system() + ' ' + (platform.architecture()[0] if platform.system() == 'Linux' else '')
+        drv = driver_for_platf[platf]
+        connectors = ['Driver=%s' % drv]
+        connectors.append('ConnectionType=Direct')
+        connectors.append('HOST=%s' % opts.get('host', ''))
+        connectors.append('PORT=%s' % opts.get('port', ''))
+        connectors.append('AuthenticationType=Plain')
+        connectors.append('UID=%s' % opts.get('username', ''))
+        connectors.append('PWD=%s' % opts.get('password', ''))
+        return [[';'.join(connectors)], {}]
 
     def last_inserted_ids(self):
         return self.context.last_inserted_ids
 
-
     def has_table(self, connection, tablename, schema=None):
         result = connection.scalar(
                         sql.text(
-                            "select count(*) from msysobjects where "
-                            "type=1 and name=:name"), name=tablename
+                            "select * from INFORMATION_SCHEMA.`TABLES` where "
+                            "name=:name"), name=tablename
                         )
         return bool(result)
 
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
-        result = connection.execute("select name from msysobjects where "
-                "type=1 and name not like 'MSys%'")
+        result = connection.execute("SHOW TABLES FROM INFORMATION_SCHEMA")
         table_names = [r[0] for r in result]
         return table_names

--- a/sqlalchemy_dremio/pyodbc.py
+++ b/sqlalchemy_dremio/pyodbc.py
@@ -25,6 +25,7 @@ from .base import DremioExecutionContext, DremioDialect
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from sqlalchemy import types as sqltypes, util
 import decimal
+import platform
 
 class _DremioNumeric_pyodbc(sqltypes.Numeric):
     """Turns Decimals with adjusted() < 0 or > 7 into strings.
@@ -95,10 +96,15 @@ class DremioExecutionContext_pyodbc(DremioExecutionContext):
 
 
 class DremioDialect_pyodbc(PyODBCConnector, DremioDialect):
-
     execution_ctx_cls = DremioExecutionContext_pyodbc
-
-    pyodbc_driver_name = 'Dremio'
+    driver_for_platf = {
+            'Linux 64bit': 'Dremio ODBC Driver 64-bit',
+            'Linux 32bit': 'Dremio ODBC Driver 32-bit',
+            'Windows' : 'Dremio Connector',
+            'Darwin': 'Dremio ODBC Driver'
+    }
+    platf = platform.system() + (' ' + platform.architecture()[0] if platform.system() == 'Linux' else '')
+    pyodbc_driver_name = driver_for_platf[platf]
 
     colspecs = util.update_copy(
         DremioDialect.colspecs,

--- a/sqlalchemy_dremio/pyodbc.py
+++ b/sqlalchemy_dremio/pyodbc.py
@@ -1,458 +1,108 @@
-# sqlalchemy_teradata/dialect.py
-# Copyright (C) 2015-2016 by Dremio
-# <see AUTHORS file>
+# sqlalchemy_dremio/pyodbc.py
+# Copyright (C) 2005-2012 the SQLAlchemy authors and contributors <see AUTHORS file>
 #
-# This module is part of sqlalchemy-teradata and is released under
+# This module is part of SQLAlchemy and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from sqlalchemy.engine import default
-from sqlalchemy import pool, String, Numeric
-from sqlalchemy.sql import select, and_, or_
-from sqlalchemy_teradata.compiler import DremioCompiler, DremioDDLCompiler, DremioTypeCompiler
-from sqlalchemy_teradata.base import DremioIdentifierPreparer, DremioExecutionContext
-from sqlalchemy.sql.expression import text, table, column, asc
-from sqlalchemy import Table, Column, Index
-import sqlalchemy.types as sqltypes
-import sqlalchemy_teradata.types as tdtypes
-from itertools import groupby
+"""
+Support for Dremio via pyodbc.
 
-# ischema names is used for reflecting columns (see get_columns in the dialect)
-ischema_names = {
-    None: sqltypes.NullType,
-    
-    'cf': tdtypes.CHAR,
-    'cv': tdtypes.VARCHAR,
-    'n' : tdtypes.NUMERIC,
-    'd' : tdtypes.DECIMAL,
-    'i' : sqltypes.INTEGER,
-    'f' : sqltypes.FLOAT,
-    'da': sqltypes.DATE,
-    'ts': tdtypes.TIMESTAMP,
-    'at': tdtypes.TIME,
-    'bv': sqltypes.VARBINARY,
-} #TODO: add the interval types and blob
+pyodbc is available at:
 
-stringtypes=[ t for t in ischema_names if issubclass(ischema_names[t],sqltypes.String)]
-        
-class DremioDialect(default.DefaultDialect):
+    http://pypi.python.org/pypi/pyodbc/
 
-    name = 'teradata'
-    driver = 'teradata'
-    default_paramstyle = 'qmark'
-    poolclass = pool.SingletonThreadPool
+Connecting
+^^^^^^^^^^
 
-    statement_compiler = DremioCompiler
-    ddl_compiler = DremioDDLCompiler
-    type_compiler = DremioTypeCompiler
-    preparer = DremioIdentifierPreparer
-    execution_ctx_cls = DremioExecutionContext
+Examples of pyodbc connection string URLs:
 
-    supports_native_boolean = False
-    supports_native_decimal = True
-    supports_unicode_statements = True
-    supports_unicode_binds = True
-    postfetch_lastrowid = False
-    implicit_returning = False
-    preexecute_autoincrement_sequences = False
+* ``dremio+pyodbc://mydsn`` - connects using the specified DSN named ``mydsn``.
 
-    construct_arguments = [
-      (Table, {
-              "post_create": None,
-              "postfixes": None
-       }),
+"""
 
-      (Index, {
-          "order_by": None,
-          "loading": None
-       }),
 
-      (Column, {
-          "compress": None,
-          "identity": None
-      })
-    ]
+from .base import DremioExecutionContext, DremioDialect
+from sqlalchemy.connectors.pyodbc import PyODBCConnector
+from sqlalchemy import types as sqltypes, util
+import decimal
 
-    def __init__(self, **kwargs):
-        super(DremioDialect, self).__init__(**kwargs)
+class _DremioNumeric_pyodbc(sqltypes.Numeric):
+    """Turns Decimals with adjusted() < 0 or > 7 into strings.
 
-    def create_connect_args(self, url):
-      if url is not None:
-        params = super(DremioDialect, self).create_connect_args(url)[1]
-        cargs = ("dremio", params['host'], params['username'], params['password'])
-        cparams = {p:params[p] for p in params if p not in\
-                                ['host', 'username', 'password']}
-        return (cargs, cparams)
+    The routines here are needed for older pyodbc versions
+    as well as current mxODBC versions.
 
-    @classmethod
-    def dbapi(cls):
+    """
 
-        """ Hook to the dbapi2.0 implementation's module"""
-        from teradata import tdodbc
-        return tdodbc
+    def bind_processor(self, dialect):
 
-    def normalize_name(self, name, **kw):
-        if name is not None:
-            return name.strip().lower()
-        return name
+        super_process = super(_DremioNumeric_pyodbc, self).\
+                        bind_processor(dialect)
 
-    def has_table(self, connection, table_name, schema=None):
+        if not dialect._need_decimal_fix:
+            return super_process
 
-        if schema is None:
-            schema=self.default_schema_name
+        def process(value):
+            if self.asdecimal and \
+                    isinstance(value, decimal.Decimal):
 
-        stmt = select([column('tablename')],
-                      from_obj=[text('dbc.tablesvx')]).where(
-                        and_(text('DatabaseName=:schema'),
-                             text('TableName=:table_name')))
+                adjusted = value.adjusted()
+                if adjusted < 0:
+                    return self._small_dec_to_string(value)
+                elif adjusted > 7:
+                    return self._large_dec_to_string(value)
 
-        res = connection.execute(stmt, schema=schema, table_name=table_name).fetchone()
-        return res is not None
-
-    def _resolve_type(self, t, **kw):
-        """
-        Resolve types for String, Numeric, Date/Time, etc. columns
-        """
-        t = self.normalize_name(t)
-        if t in ischema_names:
-            #print(t,ischema_names[t])
-            t = ischema_names[t]
-            
-            if issubclass(t, sqltypes.String):
-                return t(length=kw['length']/2 if kw['chartype']=='UNICODE' else kw['length'],\
-                            charset=kw['chartype'])
-
-            elif issubclass(t, sqltypes.Numeric):
-                return t(precision=kw['prec'], scale=kw['scale'])
-
-            elif issubclass(t, sqltypes.Time) or issubclass(t, sqltypes.DateTime):
-                #Timezone
-                tz=kw['fmt'][-1]=='Z'
-
-                #Precision                
-                prec = kw['fmt']    
-                #For some timestamps and dates, there is no precision, or indicatd in scale
-                prec = prec[prec.index('(') + 1: prec.index(')')] if '(' in prec else 0
-                prec = kw['scale'] if prec=='F' else int(prec)
-
-                #prec = int(prec[prec.index('(') + 1: prec.index(')')]) if '(' in prec else 0
-                return t(precision=prec,timezone=tz)
-
-            elif issubclass(t, sqltypes.Interval):
-                return t(day_precision=kw['prec'],second_precision=kw['scale'])
-
+            if super_process:
+                return super_process(value)
             else:
-                return t() # For types like Integer, ByteInt
+                return value
+        return process
 
-        return ischema_names[None]
+    # these routines needed for older versions of pyodbc.
+    # as of 2.1.8 this logic is integrated.
 
-    def _get_column_info(self, row):
-        """
-        Resolves the column information for get_columns given a row.
-        """
-        chartype = {
-                  0: None,
-                  1: 'LATIN',
-                  2: 'UNICODE',
-                  3: 'KANJISJIS',
-                  4: 'GRAPHIC'}
-        
-        #Handle unspecified characterset and disregard chartypes specified for non-character types (e.g. binary, json)
-        typ = self._resolve_type(row['columntype'],\
-                                    length=int(row['columnlength'] or 0),\
-                                    chartype=chartype[row['chartype'] if row['chartype'] in stringtypes else 0],\
-                                    prec=int(row['decimaltotaldigits'] or 0),\
-                                    scale=int(row['decimalfractionaldigits'] or 0),\
-                                    fmt=row['columnformat'])
+    def _small_dec_to_string(self, value):
+        return "%s0.%s%s" % (
+                    (value < 0 and '-' or ''),
+                    '0' * (abs(value.adjusted()) - 1),
+                    "".join([str(nint) for nint in value.as_tuple()[1]]))
 
-        autoinc = row['idcoltype'] in ('GA', 'GD')
-
-        return {
-                'name': self.normalize_name(row['columnname']),
-                'type': typ,
-                'nullable': row['nullable'] == u'Y',
-                'default': row['defaultvalue'],
-                'attrs': {
-                    'columnformat':row['columnformat']},
-                'autoincrement': autoinc
-               }
-
-
-    def get_columns(self, connection, table_name, schema=None, **kw):
-
-        helpView=False
-        
-        if schema is None:
-            schema = self.default_schema_name
-        
-        if int(self.server_version_info.split('.')[0])<16:
-            dbc_columninfo='dbc.ColumnsV'
-
-            #Check if the object us a view
-            stmt = select([column('tablekind')],\
-                            from_obj=[text('dbc.tablesV')]).where(\
-                            and_(text('DatabaseName=:schema'),\
-                                 text('TableName=:table_name'),\
-                                 text("tablekind='V'")))
-            res = connection.execute(stmt, schema=schema, table_name=table_name).rowcount
-            helpView = (res==1)
-
+    def _large_dec_to_string(self, value):
+        _int = value.as_tuple()[1]
+        if 'E' in str(value):
+            result = "%s%s%s" % (
+                    (value < 0 and '-' or ''),
+                    "".join([str(s) for s in _int]),
+                    "0" * (value.adjusted() - (len(_int)-1)))
         else:
-            dbc_columninfo='dbc.ColumnsQV'
-        
-        stmt = select([column('columnname'), column('columntype'),\
-                        column('columnlength'), column('chartype'),\
-                        column('decimaltotaldigits'), column('decimalfractionaldigits'),\
-                        column('columnformat'),\
-                        column('nullable'), column('defaultvalue'), column('idcoltype')],\
-                        from_obj=[text(dbc_columninfo)]).where(\
-                        and_(text('DatabaseName=:schema'),\
-                             text('TableName=:table_name')))
+            if (len(_int) - 1) > value.adjusted():
+                result = "%s%s.%s" % (
+                (value < 0 and '-' or ''),
+                "".join(
+                    [str(s) for s in _int][0:value.adjusted() + 1]),
+                "".join(
+                    [str(s) for s in _int][value.adjusted() + 1:]))
+            else:
+                result = "%s%s" % (
+                (value < 0 and '-' or ''),
+                "".join(
+                    [str(s) for s in _int][0:value.adjusted() + 1]))
+        return result
 
-        res = connection.execute(stmt, schema=schema, table_name=table_name).fetchall()
-        
-        #If this is a view in pre-16 version, get types for individual columns
-        if helpView:
-            res=[self._get_column_help(connection, schema,table_name,r['columnname']) for r in res]
-            
-        return [self._get_column_info(row) for row in res]
 
-    def _get_default_schema_name(self, connection):
-        return self.normalize_name(
-            connection.execute('select database').scalar())
+class DremioExecutionContext_pyodbc(DremioExecutionContext):
+    pass
 
-    def _get_column_help(self, connection, schema,table_name,column_name):
-        stmt='help column '+schema+'.'+table_name+'.'+column_name
-        res = connection.execute(stmt).fetchall()[0]
-        
-        return {'columnname':res['Column Name'],
-                'columntype':res['Type'],
-                'columnlength':res['Max Length'],
-                'chartype':res['Char Type'],
-                'decimaltotaldigits':res['Decimal Total Digits'],
-                'decimalfractionaldigits':res['Decimal Fractional Digits'],
-                'columnformat':res['Format'],
-                'nullable':res['Nullable'],
-                'defaultvalue':None,
-                'idcoltype':res['IdCol Type']
-                }
-    
-    def get_table_names(self, connection, schema=None, **kw):
 
-        if schema is None:
-            schema = self.default_schema_name
+class DremioDialect_pyodbc(PyODBCConnector, DremioDialect):
 
-        stmt = select([column('tablename')],
-                      from_obj=[text('dbc.TablesVX')]).where(
-                      and_(text('DatabaseName = :schema'),
-                          or_(text('tablekind=\'T\''),
-                              text('tablekind=\'O\''))))
-        res = connection.execute(stmt, schema=schema).fetchall()
-        return [self.normalize_name(name['tablename']) for name in res]
+    execution_ctx_cls = DremioExecutionContext_pyodbc
 
-    def get_schema_names(self, connection, **kw):
-        stmt = select([column('username')],
-               from_obj=[text('dbc.UsersV')],
-               order_by=[text('username')])
-        res = connection.execute(stmt).fetchall()
-        return [self.normalize_name(name['username']) for name in res]
+    pyodbc_driver_name = 'Dremio'
 
-    def get_view_definition(self, connection, view_name, schema=None, **kw):
-
-        if schema is None:
-             schema = self.default_schema_name
-
-        res = connection.execute('show table {}.{}'.format(schema, view_name)).scalar()
-        return self.normalize_name(res)
-
-    def get_view_names(self, connection, schema=None, **kw):
-
-        if schema is None:
-            schema = self.default_schema_name
-
-        stmt = select([column('tablename')],
-                      from_obj=[text('dbc.TablesVX')]).where(
-                      and_(text('DatabaseName = :schema'),
-                           text('tablekind=\'V\'')))
-
-        res = connection.execute(stmt, schema=schema).fetchall()
-        return [self.normalize_name(name['tablename']) for name in res]
-
-    def get_pk_constraint(self, connection, table_name, schema=None, **kw):
-        """
-        Override
-        TODO: Check if we need PRIMARY Indices or PRIMARY KEY Indices
-        TODO: Check for border cases (No PK Indices)
-        """
-
-        if schema is None:
-            schema = self.default_schema_name
-
-        stmt = select([column('ColumnName'), column('IndexName')],
-                      from_obj=[text('dbc.Indices')]).where(
-                          and_(text('DatabaseName = :schema'),
-                              text('TableName=:table'),
-                              text('IndexType=:indextype'))
-                      ).order_by(asc(column('IndexNumber')))
-
-        # K for Primary Key
-        res = connection.execute(stmt, schema=schema, table=table_name, indextype='K').fetchall()
-
-        index_columns = list()
-        index_name = None
-
-        for index_column in res:
-            index_columns.append(self.normalize_name(index_column['ColumnName']))
-            index_name = self.normalize_name(index_column['IndexName']) # There should be just one IndexName
-
-        return {
-            "constrained_columns": index_columns,
-            "name": index_name
+    colspecs = util.update_copy(
+        DremioDialect.colspecs,
+        {
+            sqltypes.Numeric:_DremioNumeric_pyodbc
         }
-
-    def get_unique_constraints(self, connection, table_name, schema=None, **kw):
-        """
-        Overrides base class method
-        """
-        if schema is None:
-            schema = self.default_schema_name
-
-        stmt = select([column('ColumnName'), column('IndexName')], from_obj=[text('dbc.Indices')]) \
-            .where(and_(text('DatabaseName = :schema'),
-                        text('TableName=:table'),
-                        text('IndexType=:indextype'))) \
-            .order_by(asc(column('IndexName')))
-
-        # U for Unique
-        res = connection.execute(stmt, schema=schema, table=table_name, indextype='U').fetchall()
-
-        def grouper(fk_row):
-            return {
-                'name': self.normalize_name(fk_row['IndexName']),
-            }
-
-        unique_constraints = list()
-        for constraint_info, constraint_cols in groupby(res, grouper):
-            unique_constraint = {
-                'name': self.normalize_name(constraint_info['name']),
-                'column_names': list()
-            }
-
-            for constraint_col in constraint_cols:
-                unique_constraint['column_names'].append(self.normalize_name(constraint_col['ColumnName']))
-
-            unique_constraints.append(unique_constraint)
-
-        return unique_constraints
-
-    def get_foreign_keys(self, connection, table_name, schema=None, **kw):
-        """
-        Overrides base class method
-        """
-
-        if schema is None:
-            schema = self.default_schema_name
-
-        stmt = select([column('IndexID'), column('IndexName'), column('ChildKeyColumn'), column('ParentDB'),
-                       column('ParentTable'), column('ParentKeyColumn')],
-                      from_obj=[text('DBC.All_RI_ChildrenV')]) \
-            .where(and_(text('ChildTable = :table'),
-                        text('ChildDB = :schema'))) \
-            .order_by(asc(column('IndexID')))
-
-        res = connection.execute(stmt, schema=schema, table=table_name).fetchall()
-
-        def grouper(fk_row):
-            return {
-                'name': fk_row.IndexName or fk_row.IndexID, #ID if IndexName is None
-                'schema': fk_row.ParentDB,
-                'table': fk_row.ParentTable
-            }
-
-        # TODO: Check if there's a better way
-        fk_dicts = list()
-        for constraint_info, constraint_cols in groupby(res, grouper):
-            fk_dict = {
-                'name': constraint_info['name'],
-                'constrained_columns': list(),
-                'referred_table': constraint_info['table'],
-                'referred_schema': constraint_info['schema'],
-                'referred_columns': list()
-            }
-
-            for constraint_col in constraint_cols:
-                fk_dict['constrained_columns'].append(self.normalize_name(constraint_col['ChildKeyColumn']))
-                fk_dict['referred_columns'].append(self.normalize_name(constraint_col['ParentKeyColumn']))
-
-            fk_dicts.append(fk_dict)
-
-        return fk_dicts
-
-    def get_indexes(self, connection, table_name, schema=None, **kw):
-        """
-        Overrides base class method
-        """
-
-        if schema is None:
-            schema = self.default_schema_name
-
-        stmt = select(["*"], from_obj=[text('dbc.Indices')]) \
-            .where(and_(text('DatabaseName = :schema'),
-                        text('TableName=:table'))) \
-            .order_by(asc(column('IndexName')))
-
-        res = connection.execute(stmt, schema=schema, table=table_name).fetchall()
-
-        def grouper(fk_row):
-            return {
-                'name': fk_row.IndexName or fk_row.IndexNumber, # If IndexName is None TODO: Check what to do
-                'unique': True if fk_row.UniqueFlag == 'Y' else False
-            }
-
-        # TODO: Check if there's a better way
-        indices = list()
-        for index_info, index_cols in groupby(res, grouper):
-            index_dict = {
-                'name': index_info['name'],
-                'column_names': list(),
-                'unique': index_info['unique']
-            }
-
-            for index_col in index_cols:
-                index_dict['column_names'].append(self.normalize_name(index_col['ColumnName']))
-
-            indices.append(index_dict)
-
-        return indices
-
-    def get_transaction_mode(self, connection, **kw):
-        """
-        Returns the transaction mode set for the current session.
-        T = TDBS
-        A = ANSI
-        """
-        stmt = select([text('transaction_mode')],\
-                from_obj=[text('dbc.sessioninfov')]).\
-                where(text('sessionno=SESSION'))
-
-        res = connection.execute(stmt).scalar()
-        return res
-
-    def _get_server_version_info(self, connection, **kw):
-        """
-        Returns the Dremio Database software version.
-        """
-        stmt = select([text('InfoData')],\
-                from_obj=[text('dbc.dbcinfov')]).\
-                where(text('InfoKey=\'VERSION\''))
-
-        res = connection.execute(stmt).scalar()
-        return res
-
-    def conn_supports_autocommit(self, connection, **kw):
-        """
-        Returns True if autocommit is used for this connection (underlying Dremio session)
-        else False
-        """
-        return self.get_transaction_mode(connection) == 'T'
-
-dialect = DremioDialect
+    )


### PR DESCRIPTION
I copied the Access dialect to the Dremio dialect, with only minor modifications to change the dialect name. An access with pyodbc sqlalchemy URI is able to connect the Dremio datasource to Superset, since Superset can query and visualize submissions data directly from Dremio. Eventually, we will want to build up the mapped data types and reserved words for the Dremio dialect, so we don't run into problems later on.